### PR TITLE
Revert "Use version from git-describe to better identify builds"

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -3,10 +3,7 @@ use ructe::Ructe;
 use vergen::EmitBuilder;
 
 fn main() -> Result<()> {
-    EmitBuilder::builder()
-        .git_sha(true)
-        .git_describe(true, true, None)
-        .emit()?;
+    EmitBuilder::builder().git_sha(true).emit()?;
 
     let mut ructe = Ructe::from_env()?;
     let mut statics = ructe.statics()?;

--- a/src/statics.rs
+++ b/src/statics.rs
@@ -5,8 +5,7 @@ pub struct VersionInfo<'a> {
 
 pub(crate) const VERSION_INFO: VersionInfo = VersionInfo {
     commit: env!("VERGEN_GIT_SHA"),
-    version: env!("VERGEN_GIT_DESCRIBE"),
-    // version: env!("CARGO_PKG_VERSION"),
+    version: env!("CARGO_PKG_VERSION"),
 };
 
 lazy_static! {

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -35,7 +35,7 @@
 <nav>
     <ul>
         <li>
-            <small>HoC @version_info.version - <a href="https://github.com/vbrandl/hoc/commit/@version_info.commit">@version_info.commit</a></small>
+            <small>HoC v@version_info.version - <a href="https://github.com/vbrandl/hoc/commit/@version_info.commit">@version_info.commit</a></small>
         </li>
     </ul>
 </nav>


### PR DESCRIPTION
Reverts vbrandl/hoc#600 since it generates ugly version numbers in drone CI